### PR TITLE
#370: Set refresh icon to loading on DS child members request

### DIFF
--- a/WebContent/css/styles.css
+++ b/WebContent/css/styles.css
@@ -40,7 +40,7 @@ body {
 /* Override inline width style */
 .component-text-field-fill{
     padding-left: 8px;
-    width: 100% !important;
+    flex-grow: 1;
 }
 
 .tree-card {

--- a/WebContent/js/containers/DatasetTree.js
+++ b/WebContent/js/containers/DatasetTree.js
@@ -162,7 +162,7 @@ function mapStateToProps(state) {
         datasets: stateRootDatasets.get('datasets'),
         DSChildren: stateRoot.get('DSChildren'),
         DSPath: stateRoot.get('DSPath'),
-        isFetching: stateRoot.get('isFetching'),
+        isFetching: stateRoot.get('isFetching') || stateRootDatasets.get('isFetching'),
         validated: validationRoot.get('validated'),
         username: validationRoot.get('username'),
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-mvs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-mvs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "directories": {
     "test": "tests"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-react": "^7.3.0",
     "expect": "^1.20.2",
-    "explorer-fvt-utilities": "1.0.3",
+    "explorer-fvt-utilities": "1.0.4",
     "geckodriver": "^1.19.1",
     "isomorphic-fetch": "^2.2.1",
     "mocha": "^6.1.4",


### PR DESCRIPTION
It appeared that TreeDatasets reducer already sets `isFetching` flag for REQUEST_TREE_DS_CHILD_MEMBERS etc, so I have merged it with treeDS `isFetching` flag for ConnectedDatasetTree. I do not see any conflicts here, but if needed I can create a different flag for DS child members request, like isFetchingDSChild or something.

Also I have noticed that loading icon is not actually 24px as defined in RefreshIcon and spins with some swaying. It looks like the icon has been squeezed by sibling text field, so I would suggest to replace `width: 100% !important;` with `flex-grow: 1;` for that. 

Please review and provide any feedback, thanks