### PR TITLE
Disabled disableEnforceFocus for syntax selector

### DIFF
--- a/WebContent/js/components/editor/EditorMenuBar.js
+++ b/WebContent/js/components/editor/EditorMenuBar.js
@@ -80,6 +80,7 @@ export default class EditorMenuBar extends React.Component {
                 {file ? EditorMenuBar.renderFullScreenButton(file) : null}
                 <FormControl style={{ float: 'right', paddingTop: '5px', width: '100px' }}>
                     <Select
+                        MenuProps={{disableEnforceFocus: true}}
                         value={initialSyntax}
                         onChange={this.handleSyntaxChange}
                     >

--- a/WebContent/js/components/editor/EditorMenuBar.js
+++ b/WebContent/js/components/editor/EditorMenuBar.js
@@ -80,7 +80,7 @@ export default class EditorMenuBar extends React.Component {
                 {file ? EditorMenuBar.renderFullScreenButton(file) : null}
                 <FormControl style={{ float: 'right', paddingTop: '5px', width: '100px' }}>
                     <Select
-                        MenuProps={{disableEnforceFocus: true}}
+                        MenuProps={{ disableEnforceFocus: true }}
                         value={initialSyntax}
                         onChange={this.handleSyntaxChange}
                     >


### PR DESCRIPTION
This PR addresses Issue: zowe/zlux#369

The issue was appeared because of trap focus conflict between the Orion editor and the modal part inside of material ui Select component on syntax change.
Which also leaded in some conditions to problem described in [this comment](https://github.com/zowe/orion-editor-component/pull/35#issuecomment-642761574) and some others.

Thanks,
Sergei


## PR Type
- [*] Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.