### PR TITLE
Added file property to pass to Orion editor

### DIFF
--- a/WebContent/js/components/editor/Editor.js
+++ b/WebContent/js/components/editor/Editor.js
@@ -129,6 +129,7 @@ class Editor extends React.Component {
                             handleSaveAs={this.handleSaveAs}
                         />
                         <OrionEditor
+                            file={file}
                             content={content}
                             syntax={this.state.syntax}
                             passContentToParent={this.getContent}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8061,9 +8061,9 @@
       }
     },
     "orion-editor-component": {
-      "version": "0.0.11",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/orion-editor-component/-/orion-editor-component-0.0.11.tgz",
-      "integrity": "sha1-9qSMUokocAuF3VlHYVAYib7228s=",
+      "version": "0.0.12",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/orion-editor-component/-/orion-editor-component-0.0.12.tgz",
+      "integrity": "sha1-yEQnYMTvyC4Bhj2Tlu6cAsmaiMI=",
       "requires": {
         "prop-types": "^15.5.10",
         "react": "^15.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "babel-polyfill": "^6.16.0",
     "file-loader": "^0.11.2",
     "immutable": "^3.8.1",
-    "orion-editor-component": "0.0.11",
+    "orion-editor-component": "0.0.12",
     "prop-types": "^15.5.10",
     "query-string": "^6.8.2",
     "react": "^16.4.2",


### PR DESCRIPTION
Signed-off-by: Sergei Kurnevich <sergei.kurnevich@broadcom.com>

This PR addresses Issue: zowe/zlux#292 
The final correction to issue 292 for mvs explorer. 
Solves issue described in [this comment](https://github.com/zowe/orion-editor-component/pull/35#issuecomment-647121416)

`Only one issue is still can be observed - you need two datasets (DS1, DS2) with equal content, empty will work fine for it.
Change content of one DS1 then switch to DS2, those unsaved changes from DS1 will appear as DS2 content.`

In this fix I am added the new 'file' property to pass to the Orion editor, support of that property on the other side has been added in [this PR](https://github.com/zowe/orion-editor-component/pull/35)

## PR Type
- Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- PR from forked repo? Ensure Allow edits by maintaners is set.