### PR TITLE
removed dev dependencies when packaging ui server

### DIFF
--- a/.pax/pre-packaging.sh
+++ b/.pax/pre-packaging.sh
@@ -15,7 +15,7 @@ FUNC=[CreatePax][pre-packaging]
 PWD=$(pwd)
 
 cd ./content/server
-npm install
+npm install --production
 cd ${PWD}
 
 # display extracted files


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

This PR addresses Issue: removed dev dependencies when packaging ui server to prevent size bloat

## PR Type
- [X ] Bug fix
- [ ] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.