### PR TITLE
Users/jack/fix npm failure

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -221,10 +221,10 @@ jobs:
         with:
           node-version: 10.18.1
 
-      - name: '[Prep extra] explorer-mvs exclusive - upgrade npm to v7'
-        run: |
-          npm install -g npm
-          npm -v
+      # - name: '[Prep extra] explorer-mvs exclusive - upgrade npm to v7'
+      #   run: |
+      #     npm install -g npm
+      #     npm -v
 
       - name: '[Setup] NodeJS project setup'
         uses: zowe-actions/nodejs-actions/setup@main

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -302,10 +302,10 @@ jobs:
         with:
           node-version: 10.18.1
 
-      - name: '[Prep extra] explorer-mvs exclusive - upgrade npm to v7'
-        run: |
-          npm install -g npm
-          npm -v
+      # - name: '[Prep extra] explorer-mvs exclusive - upgrade npm to v7'
+      #   run: |
+      #     npm install -g npm
+      #     npm -v
 
       - name: '[Setup] NodeJS project setup'
         uses: zowe-actions/nodejs-actions/setup@main


### PR DESCRIPTION
After npm released v8, we see a failure:

```
npm WARN npm npm does not support Node.js v10.18.1
npm WARN npm You should probably upgrade to a newer version of node as we
npm WARN npm can't make any promises that npm will work with this version.
npm WARN npm You can find the latest version at https://nodejs.org/
npm ERR! Unexpected token =
```

along with node v10.18.1.

This PR removed npm upgrade step.