### PR TITLE
disable the submit buttons + give a warning, on different Dialogs when the Dataset or DS Member name is invalid/incorrect

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,6 +11,7 @@ on:
         description: '[Release] perform release'
         required: false
         default: 'false'
+        type: boolean
 
 env:
   IMAGE_BASE_DIR: container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the MVS-Explorer will be documented in this file.
 ## <1.0.19>
 
 ### New features and enhancements
-- Enable the submit button in Dialogs when Dataset or Dataset Member name is invalid
+- Diable the submit button & give a warning message, in Dialogs when Dataset or Dataset Member name is invalid
 
 ## <1.0.17>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the MVS-Explorer will be documented in this file.
 
+## <1.0.19>
+
+### New features and enhancements
+- Enable the submit button in Dialogs when Dataset or Dataset Member name is inavlid
+
 ## <1.0.17>
 
 ### New features and enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the MVS-Explorer will be documented in this file.
 ## <1.0.19>
 
 ### New features and enhancements
-- Enable the submit button in Dialogs when Dataset or Dataset Member name is inavlid
+- Enable the submit button in Dialogs when Dataset or Dataset Member name is invalid
 
 ## <1.0.17>
 

--- a/WebContent/js/components/dialogs/AtlasDialog.js
+++ b/WebContent/js/components/dialogs/AtlasDialog.js
@@ -67,6 +67,7 @@ export default class AtlasDialog extends React.Component {
                         ,
                         <Button
                             onClick={this.handleSubmit}
+                            disabled={this.props.disableSubmit}
                         >
                             Ok
                         </Button>
@@ -90,4 +91,5 @@ AtlasDialog.propTypes = {
     dispatch: PropTypes.func.isRequired,
     submitAction: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
+    disableSubmit: PropTypes.bool,
 };

--- a/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
@@ -133,7 +133,7 @@ export default class CreateDatasetDialog extends React.Component {
         });
         // disable the Submit, when DS name is invalid
         const found = validateName('dataset', newValue);
-        if (found != null && found[0] === newValue && newValue.length <= 44) {
+        if (found != null && found[0] === newValue) {
             this.state.disableSubmit = false;
             this.state.warning = '';
         } else {

--- a/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
@@ -73,6 +73,7 @@ export default class CreateDatasetDialog extends React.Component {
             recordFormat: PRESETS.get('JCL').recordFormat,
             blockSize: PRESETS.get('JCL').blockSize,
             recordLength: PRESETS.get('JCL').recordLength,
+            disableSubmit: false,
         };
     }
 
@@ -128,6 +129,14 @@ export default class CreateDatasetDialog extends React.Component {
         this.setState({
             dsname: newValue,
         });
+        // disable the Submit, when DS name length exceeds 44 characters or any level has more than 8 characters
+        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
+        const found = newValue.match(regex);
+        if (found != null && found[0] === newValue && newValue.length <= 44) {
+            this.state.disableSubmit = false;
+        } else {
+            this.state.disableSubmit = true;
+        }
     }
 
     render() {
@@ -258,6 +267,7 @@ export default class CreateDatasetDialog extends React.Component {
                 dispatch={this.props.dispatch}
                 dialogContent={dialogContent}
                 bodyStyle={{ overflowY: 'auto' }}
+                disableSubmit={this.state.disableSubmit}
             />
         );
     }

--- a/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
@@ -74,6 +74,7 @@ export default class CreateDatasetDialog extends React.Component {
             blockSize: PRESETS.get('JCL').blockSize,
             recordLength: PRESETS.get('JCL').recordLength,
             disableSubmit: false,
+            warning: '',
         };
     }
 
@@ -134,8 +135,10 @@ export default class CreateDatasetDialog extends React.Component {
         const found = newValue.match(regex);
         if (found != null && found[0] === newValue && newValue.length <= 44) {
             this.state.disableSubmit = false;
+            this.state.warning = '';
         } else {
             this.state.disableSubmit = true;
+            this.state.warning = ' (WARNING: Invalid Name)';
         }
     }
 
@@ -162,7 +165,7 @@ export default class CreateDatasetDialog extends React.Component {
                 </div>
                 <div>
                     <DatasetName
-                        label="Dataset Name"
+                        label={`New Dataset Name ${this.state.warning}`}
                         updateName={this.updateName}
                         fullWidth={true}
                         autoFocus={true}

--- a/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
@@ -73,7 +73,7 @@ export default class CreateDatasetDialog extends React.Component {
             recordFormat: PRESETS.get('JCL').recordFormat,
             blockSize: PRESETS.get('JCL').blockSize,
             recordLength: PRESETS.get('JCL').recordLength,
-            disableSubmit: false,
+            disableSubmit: true,
             warning: '',
         };
     }

--- a/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateDatasetDialog.js
@@ -17,6 +17,7 @@ import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import { Map } from 'immutable';
 import { createDataset } from '../../../actions/treeDatasets';
+import validateName from '../../../utilities/sharedUtils';
 import PRESETS from './datasetPresets';
 import AtlasDialog from '../AtlasDialog';
 import DatasetName from './DatasetName';
@@ -130,9 +131,8 @@ export default class CreateDatasetDialog extends React.Component {
         this.setState({
             dsname: newValue,
         });
-        // disable the Submit, when DS name length exceeds 44 characters or any level has more than 8 characters
-        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
-        const found = newValue.match(regex);
+        // disable the Submit, when DS name is invalid
+        const found = validateName('dataset', newValue);
         if (found != null && found[0] === newValue && newValue.length <= 44) {
             this.state.disableSubmit = false;
             this.state.warning = '';

--- a/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
@@ -21,6 +21,7 @@ export default class CreateMemberDialog extends React.Component {
 
         this.state = {
             memberName: '',
+            disableSubmit: false,
         };
     }
 
@@ -33,6 +34,14 @@ export default class CreateMemberDialog extends React.Component {
         this.setState({
             memberName: newValue,
         });
+        // disable the Submit, when PDS member name has length more than 8
+        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7})/g;
+        const found = newValue.match(regex);
+        if (found != null && found[0] === newValue) {
+            this.state.disableSubmit = false;
+        } else {
+            this.state.disableSubmit = true;
+        }
     }
 
     render() {
@@ -52,6 +61,7 @@ export default class CreateMemberDialog extends React.Component {
                 dialogReturn={this.props.dialogReturn}
                 dispatch={this.props.dispatch}
                 dialogContent={dialogContent}
+                disableSubmit={this.state.disableSubmit}
             />
         );
     }

--- a/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
@@ -22,6 +22,7 @@ export default class CreateMemberDialog extends React.Component {
         this.state = {
             memberName: '',
             disableSubmit: false,
+            warning: '',
         };
     }
 
@@ -39,15 +40,17 @@ export default class CreateMemberDialog extends React.Component {
         const found = newValue.match(regex);
         if (found != null && found[0] === newValue) {
             this.state.disableSubmit = false;
+            this.state.warning = '';
         } else {
             this.state.disableSubmit = true;
+            this.state.warning = ' (WARNING: Invalid Name)';
         }
     }
 
     render() {
         const dialogContent = (
             <UpperCaseTextField
-                label="New Member Name"
+                label={`New Member Name ${this.state.warning}`}
                 fieldChangedCallback={this.updateName}
                 fullWidth={true}
                 autoFocus={true}

--- a/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
@@ -21,7 +21,7 @@ export default class CreateMemberDialog extends React.Component {
 
         this.state = {
             memberName: '',
-            disableSubmit: false,
+            disableSubmit: true,
             warning: '',
         };
     }

--- a/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
+++ b/WebContent/js/components/dialogs/datasets/CreateMemberDialog.js
@@ -11,6 +11,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createMember } from '../../../actions/treeDatasets';
+import validateName from '../../../utilities/sharedUtils';
 import UpperCaseTextField from '../UpperCaseTextField';
 import AtlasDialog from '../AtlasDialog';
 
@@ -35,9 +36,8 @@ export default class CreateMemberDialog extends React.Component {
         this.setState({
             memberName: newValue,
         });
-        // disable the Submit, when PDS member name has length more than 8
-        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7})/g;
-        const found = newValue.match(regex);
+        // disable the Submit, when PDS member name is invalid
+        const found = validateName('datasetMember', newValue);
         if (found != null && found[0] === newValue) {
             this.state.disableSubmit = false;
             this.state.warning = '';

--- a/WebContent/js/components/dialogs/datasets/DatasetName.js
+++ b/WebContent/js/components/dialogs/datasets/DatasetName.js
@@ -12,11 +12,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import UpperCaseTextField from '../UpperCaseTextField';
 
-const DatasetName = ({ updateName, ...props }) => {
+const DatasetName = ({ updateName, label, ...props }) => {
     return (
         <UpperCaseTextField
             {...props}
-            label="New Dataset Name"
+            label={label}
             fieldChangedCallback={updateName}
         />
     );
@@ -26,4 +26,5 @@ export default DatasetName;
 
 DatasetName.propTypes = {
     updateName: PropTypes.func.isRequired,
+    label: PropTypes.string.isRequired,
 };

--- a/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
+++ b/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
@@ -11,6 +11,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { saveAsDataset, saveAsDatasetMember } from '../../../actions/editor';
+import validateName from '../../../utilities/sharedUtils';
 import DatasetName from './DatasetName';
 import DatasetMemberName from './DatasetMemberName';
 import AtlasDialog from '../AtlasDialog';
@@ -51,9 +52,8 @@ export default class DatasetSaveAsDialog extends React.Component {
         this.setState({
             newDSName: newValue,
         });
-        // disable the Submit, when DS name length exceeds 44 characters or any level has more than 8 characters
-        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
-        const found = newValue.match(regex);
+        // disable the Submit, when DS name is invalid
+        const found = validateName('dataset', newValue);
         if (found != null && found[0] === newValue && newValue.length <= 44) {
             this.state.disableSubmit = false;
             this.state.warning = '';
@@ -68,8 +68,7 @@ export default class DatasetSaveAsDialog extends React.Component {
             newDSMember: newValue,
         });
         // disable the Submit, when PDS member name is invalid
-        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7})/g;
-        const found = newValue.match(regex);
+        const found = validateName('datasetMember', newValue);
         if (found != null && found[0] === newValue) {
             this.state.disableSubmit = false;
             this.state.warning = '';

--- a/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
+++ b/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
@@ -31,6 +31,7 @@ export default class DatasetSaveAsDialog extends React.Component {
         this.state = {
             newDSName: '',
             newDSMember: '',
+            disableSubmit: false,
         };
     }
 
@@ -49,12 +50,28 @@ export default class DatasetSaveAsDialog extends React.Component {
         this.setState({
             newDSName: newValue,
         });
+        // validate the DataSetName
+        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7}){0,3})/g;
+        const found = newValue.match(regex);
+        if (found != null && found[0] === newValue) {
+            this.state.disableSubmit = false;
+        } else {
+            this.state.disableSubmit = true;
+        }
     }
 
     updateMember(newValue) {
         this.setState({
             newDSMember: newValue,
         });
+        // disable the Submit, when PDS member name is invalid
+        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7})/g;
+        const found = newValue.match(regex);
+        if (found != null && found[0] === newValue) {
+            this.state.disableSubmit = false;
+        } else {
+            this.state.disableSubmit = true;
+        }
     }
 
     render() {
@@ -88,6 +105,7 @@ export default class DatasetSaveAsDialog extends React.Component {
                 dispatch={dispatch}
                 dialogContent={DatasetSaveAsDialog.isMember(file) ? dialogContentMember : dialogContentDataset}
                 bodyStyle={{ overflowY: 'auto' }}
+                disableSubmit={this.state.disableSubmit}
             />
         );
     }

--- a/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
+++ b/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
@@ -32,11 +32,12 @@ export default class DatasetSaveAsDialog extends React.Component {
             newDSName: '',
             newDSMember: '',
             disableSubmit: false,
+            warning: '',
         };
     }
 
     componentDidMount() {
-        this.updateName('sr');
+        this.updateName('SR');
     }
 
     submitAction = () => {
@@ -55,8 +56,10 @@ export default class DatasetSaveAsDialog extends React.Component {
         const found = newValue.match(regex);
         if (found != null && found[0] === newValue && newValue.length <= 44) {
             this.state.disableSubmit = false;
+            this.state.warning = '';
         } else {
             this.state.disableSubmit = true;
+            this.state.warning = ' (WARNING: Invalid Name)';
         }
     }
 
@@ -69,8 +72,10 @@ export default class DatasetSaveAsDialog extends React.Component {
         const found = newValue.match(regex);
         if (found != null && found[0] === newValue) {
             this.state.disableSubmit = false;
+            this.state.warning = '';
         } else {
             this.state.disableSubmit = true;
+            this.state.warning = ' (WARNING: Invalid Name)';
         }
     }
 
@@ -79,7 +84,7 @@ export default class DatasetSaveAsDialog extends React.Component {
         const dialogContentMember = (
             <div>
                 <DatasetMemberName
-                    label="New Member Name"
+                    label={`New Member Name ${this.state.warning}`}
                     updateMember={this.updateMember}
                     fullWidth={true}
                     autoFocus={true}
@@ -89,7 +94,7 @@ export default class DatasetSaveAsDialog extends React.Component {
         const dialogContentDataset = (
             <div>
                 <DatasetName
-                    label="New Dataset Name"
+                    label={`New Dataset Name ${this.state.warning}`}
                     updateName={this.updateName}
                     fullWidth={true}
                     autoFocus={true}

--- a/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
+++ b/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
@@ -50,10 +50,10 @@ export default class DatasetSaveAsDialog extends React.Component {
         this.setState({
             newDSName: newValue,
         });
-        // validate the DataSetName
-        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7}){0,3})/g;
+        // disable the Submit, when DS name length exceeds 44 characters or any level has more than 8 characters
+        const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
         const found = newValue.match(regex);
-        if (found != null && found[0] === newValue) {
+        if (found != null && found[0] === newValue && newValue.length <= 44) {
             this.state.disableSubmit = false;
         } else {
             this.state.disableSubmit = true;

--- a/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
+++ b/WebContent/js/components/dialogs/datasets/DatasetSaveAsDialog.js
@@ -54,7 +54,7 @@ export default class DatasetSaveAsDialog extends React.Component {
         });
         // disable the Submit, when DS name is invalid
         const found = validateName('dataset', newValue);
-        if (found != null && found[0] === newValue && newValue.length <= 44) {
+        if (found != null && found[0] === newValue) {
             this.state.disableSubmit = false;
             this.state.warning = '';
         } else {

--- a/WebContent/js/components/dialogs/datasets/RenameDialog.js
+++ b/WebContent/js/components/dialogs/datasets/RenameDialog.js
@@ -12,6 +12,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AtlasDialog from '../AtlasDialog';
 import { renameDataset } from '../../../actions/treeDatasets';
+import validateName from '../../../utilities/sharedUtils';
 import UpperCaseTextField from '../UpperCaseTextField';
 
 export default class RenameDialog extends React.Component {
@@ -35,11 +36,10 @@ export default class RenameDialog extends React.Component {
         this.setState({
             newName: newValue,
         });
-        // check for the validity of Dataset Member Name
+        // disable the Submit, when DS name is invalid
         if (this.props.title.includes('Rename Dataset Member')) {
             const newMemeberName = newValue.substring(newValue.indexOf('('), newValue.length);
-            const regex = /^(\([A-Z#@$][A-Z0-9#@$-]{0,7}\))/g;
-            const found = newMemeberName.match(regex);
+            const found = validateName('renameDatasetMember', newMemeberName);
             if (found != null && found[0] === newMemeberName) {
                 this.state.disableSubmit = false;
                 this.state.warning = '';
@@ -47,13 +47,9 @@ export default class RenameDialog extends React.Component {
                 this.state.disableSubmit = true;
                 this.state.warning = ' (WARNING: Invalid Name)';
             }
-        /*
-        * check for the validity of Dataset Name and
-        * disable the Submit, when Dataset name length exceeds 44 characters or any level has more than 8 characters
-        */
+        // disable the Submit, when Dataset name is invalid
         } else {
-            const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
-            const found = newValue.match(regex);
+            const found = validateName('dataset', newValue);
             if (found != null && found[0] === newValue && newValue.length <= 44) {
                 this.state.disableSubmit = false;
                 this.state.warning = '';

--- a/WebContent/js/components/dialogs/datasets/RenameDialog.js
+++ b/WebContent/js/components/dialogs/datasets/RenameDialog.js
@@ -21,6 +21,7 @@ export default class RenameDialog extends React.Component {
 
         this.state = {
             newName: props.oldName,
+            disableSubmit: false,
         };
     }
 
@@ -33,6 +34,26 @@ export default class RenameDialog extends React.Component {
         this.setState({
             newName: newValue,
         });
+        // check for the validity of Dataset Member Name
+        if (this.props.title.includes('Rename Dataset Member')) {
+            const newMemeberName = newValue.substring(newValue.indexOf('('), newValue.length);
+            const regex = /^(\([A-Z#@$][A-Z0-9#@$-]{0,7}\))/g;
+            const found = newMemeberName.match(regex);
+            if (found != null && found[0] === newMemeberName) {
+                this.state.disableSubmit = false;
+            } else {
+                this.state.disableSubmit = true;
+            }
+        // check for the validity of Dataset Name
+        } else {
+            const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7}){0,3})/g;
+            const found = newValue.match(regex);
+            if (found != null && found[0] === newValue) {
+                this.state.disableSubmit = false;
+            } else {
+                this.state.disableSubmit = true;
+            }
+        }
     }
 
     render() {
@@ -60,6 +81,7 @@ export default class RenameDialog extends React.Component {
                     dialogContent={dialogContent}
                     oldName={oldName}
                     isOpenInViewer={isOpenInViewer}
+                    disableSubmit={this.state.disableSubmit}
                 />
             </div>
         );

--- a/WebContent/js/components/dialogs/datasets/RenameDialog.js
+++ b/WebContent/js/components/dialogs/datasets/RenameDialog.js
@@ -38,9 +38,9 @@ export default class RenameDialog extends React.Component {
         });
         // disable the Submit, when DS name is invalid
         if (this.props.title.includes('Rename Dataset Member')) {
-            const newMemeberName = newValue.substring(newValue.indexOf('('), newValue.length);
-            const found = validateName('renameDatasetMember', newMemeberName);
-            if (found != null && found[0] === newMemeberName) {
+            const newMemberName = newValue.substring(newValue.indexOf('('), newValue.length);
+            const found = validateName('renameDatasetMember', newMemberName);
+            if (found != null && found[0] === newMemberName) {
                 this.state.disableSubmit = false;
                 this.state.warning = '';
             } else {

--- a/WebContent/js/components/dialogs/datasets/RenameDialog.js
+++ b/WebContent/js/components/dialogs/datasets/RenameDialog.js
@@ -50,7 +50,7 @@ export default class RenameDialog extends React.Component {
         // disable the Submit, when Dataset name is invalid
         } else {
             const found = validateName('dataset', newValue);
-            if (found != null && found[0] === newValue && newValue.length <= 44) {
+            if (found != null && found[0] === newValue) {
                 this.state.disableSubmit = false;
                 this.state.warning = '';
             } else {

--- a/WebContent/js/components/dialogs/datasets/RenameDialog.js
+++ b/WebContent/js/components/dialogs/datasets/RenameDialog.js
@@ -44,11 +44,14 @@ export default class RenameDialog extends React.Component {
             } else {
                 this.state.disableSubmit = true;
             }
-        // check for the validity of Dataset Name
+        /*
+        * check for the validity of Dataset Name and
+        * disable the Submit, when Dataset name length exceeds 44 characters or any level has more than 8 characters
+        */
         } else {
-            const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7}){0,3})/g;
+            const regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
             const found = newValue.match(regex);
-            if (found != null && found[0] === newValue) {
+            if (found != null && found[0] === newValue && newValue.length <= 44) {
                 this.state.disableSubmit = false;
             } else {
                 this.state.disableSubmit = true;

--- a/WebContent/js/components/dialogs/datasets/RenameDialog.js
+++ b/WebContent/js/components/dialogs/datasets/RenameDialog.js
@@ -22,6 +22,7 @@ export default class RenameDialog extends React.Component {
         this.state = {
             newName: props.oldName,
             disableSubmit: false,
+            warning: '',
         };
     }
 
@@ -41,8 +42,10 @@ export default class RenameDialog extends React.Component {
             const found = newMemeberName.match(regex);
             if (found != null && found[0] === newMemeberName) {
                 this.state.disableSubmit = false;
+                this.state.warning = '';
             } else {
                 this.state.disableSubmit = true;
+                this.state.warning = ' (WARNING: Invalid Name)';
             }
         /*
         * check for the validity of Dataset Name and
@@ -53,8 +56,10 @@ export default class RenameDialog extends React.Component {
             const found = newValue.match(regex);
             if (found != null && found[0] === newValue && newValue.length <= 44) {
                 this.state.disableSubmit = false;
+                this.state.warning = '';
             } else {
                 this.state.disableSubmit = true;
+                this.state.warning = ' (WARNING: Invalid Name)';
             }
         }
     }
@@ -67,6 +72,7 @@ export default class RenameDialog extends React.Component {
         const dialogContent = (
             <UpperCaseTextField
                 placeholder="New name"
+                label={`New Name ${this.state.warning}`}
                 fieldChangedCallback={this.updateName}
                 value={this.state.newName}
                 fullWidth={true}

--- a/WebContent/js/utilities/sharedUtils.js
+++ b/WebContent/js/utilities/sharedUtils.js
@@ -17,5 +17,5 @@ export default function validateName(type, nameToValidate) {
         default: /* renameDatasetMember */
             regex = /^(\([A-Z#@$][A-Z0-9#@$-]{0,7}\))/g;
     }
-    return nameToValidate.match(regex);
+    return nameToValidate.length <= 44 ? nameToValidate.match(regex) : null;
 }

--- a/WebContent/js/utilities/sharedUtils.js
+++ b/WebContent/js/utilities/sharedUtils.js
@@ -2,6 +2,7 @@
 * Each name segment (qualifier) is 1 to 8 characters, the first of which must be alphabetic (A to Z) or national (# @ $).
 * The remaining seven characters are either alphabetic, numeric (0 - 9), national, a hyphen (-). Name segments are separated by a period (.).
 * Data set names must not exceed 44 characters, including all name segments and periods.
+* https://www.ibm.com/docs/en/zos/2.1.0?topic=sets-data-set-names
 */
 export default function validateName(type, nameToValidate) {
     let regex = '';

--- a/WebContent/js/utilities/sharedUtils.js
+++ b/WebContent/js/utilities/sharedUtils.js
@@ -1,0 +1,20 @@
+/*
+* Each name segment (qualifier) is 1 to 8 characters, the first of which must be alphabetic (A to Z) or national (# @ $).
+* The remaining seven characters are either alphabetic, numeric (0 - 9), national, a hyphen (-). Name segments are separated by a period (.).
+* Data set names must not exceed 44 characters, including all name segments and periods.
+*/
+export default function validateName(type, nameToValidate) {
+    let regex = '';
+
+    switch (type) {
+        case 'dataset':
+            regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7}(\.[A-Z#@$][A-Z0-9#@$-]{0,7})*)/g;
+            break;
+        case 'datasetMember':
+            regex = /^([A-Z#@$][A-Z0-9#@$-]{0,7})/g;
+            break;
+        default: /* renameDatasetMember */
+            regex = /^(\([A-Z#@$][A-Z0-9#@$-]{0,7}\))/g;
+    }
+    return nameToValidate.match(regex);
+}


### PR DESCRIPTION
disable the submit buttons on different Dialogs when the Dataset or DS Member name is invalid/incorrect as per https://www.ibm.com/docs/en/zos/2.1.0?topic=sets-data-set-names

Signed-off-by: Adarshdeep Cheema <adarshdeep.cheema@ibm.com>

This PR addresses Issue: https://github.com/zowe/zlux/issues/301

## PR Type
- [ ] Bug fix
- [X] Feature
- [ ] Other (Please indicate)

## PR Checklist
- [ ] PR completes `npm run preCommit` without error
- [ ] Relevant Test cases have been added (Unit and or FVT)
- [ ] Relevant update to CHANGELOG.md
- [ ] PR from forked repo? Ensure Allow edits by maintaners is set.