### PR TITLE
Bump babel loader to fix loader-utils vulnerability warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "explorer-mvs",
             "version": "2.0.4",
             "license": "EPL-2.0",
             "dependencies": {
@@ -38,7 +39,7 @@
                 "@types/mocha": "9.0.0",
                 "@types/node": "13.7.1",
                 "@types/selenium-webdriver": "4.0.8",
-                "babel-loader": "8.0.0",
+                "babel-loader": "8.3.0",
                 "babel-plugin-react-html-attrs": "2.0.0",
                 "chai": "4.2.0",
                 "chai-things": "0.2.0",
@@ -3180,22 +3181,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/array.prototype.reduce": {
-            "version": "1.0.5",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
-            "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.20.4",
-                "es-array-method-boxes-properly": "^1.0.0",
-                "is-string": "^1.0.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/assertion-error": {
             "version": "1.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3263,18 +3248,18 @@
             "dev": true
         },
         "node_modules/babel-loader": {
-            "version": "8.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/babel-loader/-/babel-loader-8.0.0.tgz",
-            "integrity": "sha512-lBUGBz411lSfT+8MHPEaqIVQ44odS1D/wxuTMhijqHc9arZR6jhJEaJa0RpZlCSITZoeK6xoDXTaVTrSoFD7IQ==",
+            "version": "8.3.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/babel-loader/-/babel-loader-8.3.0.tgz",
+            "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
             "dev": true,
             "dependencies": {
-                "find-cache-dir": "^1.0.0",
-                "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "util.promisify": "^1.0.0"
+                "find-cache-dir": "^3.3.1",
+                "loader-utils": "^2.0.0",
+                "make-dir": "^3.1.0",
+                "schema-utils": "^2.6.5"
             },
             "engines": {
-                "node": ">= 6.9"
+                "node": ">= 8.9"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0",
@@ -3282,117 +3267,92 @@
             }
         },
         "node_modules/babel-loader/node_modules/find-cache-dir": {
-            "version": "1.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-            "integrity": "sha512-46TFiBOzX7xq/PcSWfFwkyjpemdRnMe31UQF+os0y+1W3k95f6R4SEt02Hj4p3X0Mir9gfrkmOtshFidS0VPUg==",
+            "version": "3.3.2",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
             "dev": true,
             "dependencies": {
                 "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/babel-loader/node_modules/find-up": {
-            "version": "2.1.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+            "version": "4.1.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
             "dependencies": {
-                "locate-path": "^2.0.0"
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/babel-loader/node_modules/locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+            "version": "5.0.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
             "dependencies": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "^4.1.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/babel-loader/node_modules/make-dir": {
-            "version": "1.3.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-1.3.0.tgz",
-            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "version": "3.1.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
             "dev": true,
             "dependencies": {
-                "pify": "^3.0.0"
+                "semver": "^6.0.0"
             },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/babel-loader/node_modules/p-limit": {
-            "version": "1.3.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-            "dev": true,
-            "dependencies": {
-                "p-try": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/babel-loader/node_modules/p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+            "version": "4.1.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
             "dependencies": {
-                "p-limit": "^1.1.0"
+                "p-limit": "^2.2.0"
             },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/babel-loader/node_modules/p-try": {
-            "version": "1.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/babel-loader/node_modules/path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/babel-loader/node_modules/pify": {
-            "version": "3.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/babel-loader/node_modules/pkg-dir": {
-            "version": "2.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-2.0.0.tgz",
-            "integrity": "sha512-ojakdnUgL5pzJYWw2AIDEupaQCX5OPbM688ZevubICjdIX01PRSYKqm33fJoCOJBRseYCTUlQRnBNX+Pchaejw==",
+            "version": "4.2.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
             "dependencies": {
-                "find-up": "^2.1.0"
+                "find-up": "^4.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
+            }
+        },
+        "node_modules/babel-loader/node_modules/schema-utils": {
+            "version": "2.7.1",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-2.7.1.tgz",
+            "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.5",
+                "ajv": "^6.12.4",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 8.9.0"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
@@ -4316,20 +4276,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/copy-webpack-plugin/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
         "node_modules/copy-webpack-plugin/node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-5.0.0.tgz",
@@ -5110,12 +5056,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-            "dev": true
         },
         "node_modules/es-get-iterator": {
             "version": "1.1.2",
@@ -6120,20 +6060,6 @@
             },
             "peerDependencies": {
                 "webpack": "^4.0.0 || ^5.0.0"
-            }
-        },
-        "node_modules/file-loader/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "devOptional": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
             }
         },
         "node_modules/fill-range": {
@@ -8244,29 +8170,16 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-            "dev": true,
+            "version": "2.0.4",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
+                "json5": "^2.1.2"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/loader-utils/node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
+                "node": ">=8.9.0"
             }
         },
         "node_modules/locate-path": {
@@ -9518,21 +9431,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.getownpropertydescriptors": {
-            "version": "2.1.5",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
-            "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
-            "dev": true,
-            "dependencies": {
-                "array.prototype.reduce": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.20.4"
-            },
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/object.getprototypeof": {
@@ -12413,37 +12311,11 @@
                 }
             }
         },
-        "node_modules/url-loader/node_modules/loader-utils": {
-            "version": "2.0.4",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
-        },
-        "node_modules/util.promisify": {
-            "version": "1.1.1",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util.promisify/-/util.promisify-1.1.1.tgz",
-            "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "for-each": "^0.3.3",
-                "has-symbols": "^1.0.1",
-                "object.getownpropertydescriptors": "^2.1.1"
-            }
         },
         "node_modules/utila": {
             "version": "0.4.0",
@@ -15793,19 +15665,6 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
-        "array.prototype.reduce": {
-            "version": "1.0.5",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
-            "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.20.4",
-                "es-array-method-boxes-properly": "^1.0.0",
-                "is-string": "^1.0.7"
-            }
-        },
         "assertion-error": {
             "version": "1.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -15861,99 +15720,83 @@
             "dev": true
         },
         "babel-loader": {
-            "version": "8.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/babel-loader/-/babel-loader-8.0.0.tgz",
-            "integrity": "sha512-lBUGBz411lSfT+8MHPEaqIVQ44odS1D/wxuTMhijqHc9arZR6jhJEaJa0RpZlCSITZoeK6xoDXTaVTrSoFD7IQ==",
+            "version": "8.3.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/babel-loader/-/babel-loader-8.3.0.tgz",
+            "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "^1.0.0",
-                "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "util.promisify": "^1.0.0"
+                "find-cache-dir": "^3.3.1",
+                "loader-utils": "^2.0.0",
+                "make-dir": "^3.1.0",
+                "schema-utils": "^2.6.5"
             },
             "dependencies": {
                 "find-cache-dir": {
-                    "version": "1.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-                    "integrity": "sha512-46TFiBOzX7xq/PcSWfFwkyjpemdRnMe31UQF+os0y+1W3k95f6R4SEt02Hj4p3X0Mir9gfrkmOtshFidS0VPUg==",
+                    "version": "3.3.2",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+                    "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
                     "dev": true,
                     "requires": {
                         "commondir": "^1.0.1",
-                        "make-dir": "^1.0.0",
-                        "pkg-dir": "^2.0.0"
+                        "make-dir": "^3.0.2",
+                        "pkg-dir": "^4.1.0"
                     }
                 },
                 "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+                    "version": "4.1.0",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "locate-path": {
-                    "version": "2.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-2.0.0.tgz",
-                    "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+                    "version": "5.0.0",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "make-dir": {
-                    "version": "1.3.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-1.3.0.tgz",
-                    "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+                    "version": "3.1.0",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "1.3.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-limit/-/p-limit-1.3.0.tgz",
-                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^1.0.0"
+                        "semver": "^6.0.0"
                     }
                 },
                 "p-locate": {
-                    "version": "2.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-2.0.0.tgz",
-                    "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+                    "version": "4.1.0",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
-                "p-try": {
-                    "version": "1.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-                    "dev": true
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-                    "dev": true
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-                    "dev": true
-                },
                 "pkg-dir": {
-                    "version": "2.0.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-2.0.0.tgz",
-                    "integrity": "sha512-ojakdnUgL5pzJYWw2AIDEupaQCX5OPbM688ZevubICjdIX01PRSYKqm33fJoCOJBRseYCTUlQRnBNX+Pchaejw==",
+                    "version": "4.2.0",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/pkg-dir/-/pkg-dir-4.2.0.tgz",
+                    "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^2.1.0"
+                        "find-up": "^4.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "2.7.1",
+                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-2.7.1.tgz",
+                    "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.5",
+                        "ajv": "^6.12.4",
+                        "ajv-keywords": "^3.5.2"
                     }
                 }
             }
@@ -16722,17 +16565,6 @@
                         "path-exists": "^4.0.0"
                     }
                 },
-                "loader-utils": {
-                    "version": "2.0.4",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
-                    "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                },
                 "locate-path": {
                     "version": "5.0.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/locate-path/-/locate-path-5.0.0.tgz",
@@ -17373,12 +17205,6 @@
                 "unbox-primitive": "^1.0.2",
                 "which-typed-array": "^1.1.9"
             }
-        },
-        "es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-            "dev": true
         },
         "es-get-iterator": {
             "version": "1.1.2",
@@ -18183,19 +18009,6 @@
             "requires": {
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "2.0.4",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
-                    "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-                    "devOptional": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                }
             }
         },
         "fill-range": {
@@ -19898,25 +19711,13 @@
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
         },
         "loader-utils": {
-            "version": "1.4.2",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-1.4.2.tgz",
-            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-            "dev": true,
+            "version": "2.0.4",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.2",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-1.0.2.tgz",
-                    "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                }
+                "json5": "^2.1.2"
             }
         },
         "locate-path": {
@@ -20918,18 +20719,6 @@
             "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
             "dev": true,
             "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.4",
-                "es-abstract": "^1.20.4"
-            }
-        },
-        "object.getownpropertydescriptors": {
-            "version": "2.1.5",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
-            "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
-            "dev": true,
-            "requires": {
-                "array.prototype.reduce": "^1.0.5",
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
                 "es-abstract": "^1.20.4"
@@ -23277,18 +23066,6 @@
                 "loader-utils": "^2.0.0",
                 "mime-types": "^2.1.27",
                 "schema-utils": "^3.0.0"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "2.0.4",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
-                    "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^2.1.2"
-                    }
-                }
             }
         },
         "util-deprecate": {
@@ -23296,19 +23073,6 @@
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
-        },
-        "util.promisify": {
-            "version": "1.1.1",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/util.promisify/-/util.promisify-1.1.1.tgz",
-            "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "for-each": "^0.3.3",
-                "has-symbols": "^1.0.1",
-                "object.getownpropertydescriptors": "^2.1.1"
-            }
         },
         "utila": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@types/mocha": "9.0.0",
         "@types/node": "13.7.1",
         "@types/selenium-webdriver": "4.0.8",
-        "babel-loader": "8.0.0",
+        "babel-loader": "8.3.0",
         "babel-plugin-react-html-attrs": "2.0.0",
         "chai": "4.2.0",
         "chai-things": "0.2.0",


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

This PR addresses Issues of public vulnerability reports that certain versions of loader-utils were not to be used, though the impact of some of the reports were disputed as real or not, the fixes are available so we have updated it.

## PR Type
- [x] Chore

## PR Checklist
- [x] PR completes `npm run preCommit` without error
