### PR TITLE
Move url-loader to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "explorer-mvs",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "license": "EPL-2.0",
             "dependencies": {
                 "@material-ui/core": "4.11.0",
@@ -26,7 +25,6 @@
                 "redux-immutable": "4.0.0",
                 "redux-logger": "3.0.6",
                 "redux-thunk": "2.3.0",
-                "url-loader": "4.1.1",
                 "whatwg-fetch": "2.0.3"
             },
             "devDependencies": {
@@ -75,6 +73,7 @@
                 "terser-webpack-plugin": "3.0.6",
                 "ts-node": "8.6.2",
                 "typescript": "3.7.5",
+                "url-loader": "4.1.1",
                 "webpack": "5.59.1",
                 "webpack-bundle-analyzer": "4.5.0",
                 "webpack-cli": "4.9.1",
@@ -1969,6 +1968,7 @@
             "version": "3.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1977,6 +1977,7 @@
             "version": "1.1.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1985,6 +1986,7 @@
             "version": "0.3.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/source-map/-/source-map-0.3.2.tgz",
             "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -1994,6 +1996,7 @@
             "version": "0.3.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
             "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2006,12 +2009,14 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.17",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
             "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -2406,6 +2411,7 @@
             "version": "8.4.10",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/eslint/-/eslint-8.4.10.tgz",
             "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
+            "dev": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -2415,6 +2421,7 @@
             "version": "3.7.4",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
             "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+            "dev": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -2423,7 +2430,8 @@
         "node_modules/@types/estree": {
             "version": "0.0.50",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+            "dev": true
         },
         "node_modules/@types/express": {
             "version": "4.17.15",
@@ -2482,7 +2490,8 @@
         "node_modules/@types/json-schema": {
             "version": "7.0.11",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "dev": true
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -2520,7 +2529,8 @@
         "node_modules/@types/node": {
             "version": "13.7.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/node/-/node-13.7.1.tgz",
-            "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
+            "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
+            "dev": true
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.5",
@@ -2700,6 +2710,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ast/-/ast-1.11.1.tgz",
             "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -2708,22 +2719,26 @@
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
             "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -2733,12 +2748,14 @@
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
             "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2750,6 +2767,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
             "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "dev": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -2758,6 +2776,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
             "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "dev": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -2765,12 +2784,14 @@
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
             "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2786,6 +2807,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
             "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -2798,6 +2820,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
             "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2809,6 +2832,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
             "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -2822,6 +2846,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
             "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "dev": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
@@ -2866,12 +2891,14 @@
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -2954,6 +2981,7 @@
             "version": "6.12.6",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2983,6 +3011,8 @@
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -2994,12 +3024,15 @@
             "version": "1.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
             }
@@ -3445,6 +3478,7 @@
             "version": "5.2.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -3564,6 +3598,7 @@
             "version": "4.21.4",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserslist/-/browserslist-4.21.4.tgz",
             "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+            "dev": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -3589,7 +3624,8 @@
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
         },
         "node_modules/buffer-indexof": {
             "version": "1.1.1",
@@ -3760,7 +3796,8 @@
         "node_modules/caniuse-lite": {
             "version": "1.0.30001442",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-            "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow=="
+            "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+            "dev": true
         },
         "node_modules/chai": {
             "version": "4.2.0",
@@ -3842,6 +3879,7 @@
             "version": "1.0.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -4929,7 +4967,8 @@
         "node_modules/electron-to-chromium": {
             "version": "1.4.284",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -4941,6 +4980,7 @@
             "version": "3.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
             "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -4967,6 +5007,7 @@
             "version": "5.12.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
             "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -5076,7 +5117,8 @@
         "node_modules/es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.1",
@@ -5131,6 +5173,7 @@
             "version": "3.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5433,6 +5476,7 @@
             "version": "5.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -5700,6 +5744,7 @@
             "version": "4.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -5711,6 +5756,7 @@
             "version": "5.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -5719,6 +5765,7 @@
             "version": "4.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -5751,6 +5798,7 @@
             "version": "3.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -5966,7 +6014,8 @@
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.2.12",
@@ -5987,7 +6036,8 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -6050,7 +6100,7 @@
             "version": "6.2.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/file-loader/-/file-loader-6.2.0.tgz",
             "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0"
@@ -6518,7 +6568,8 @@
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true
         },
         "node_modules/globals": {
             "version": "11.12.0",
@@ -6601,7 +6652,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "node_modules/growl": {
             "version": "1.10.5",
@@ -7928,12 +7980,14 @@
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -7951,6 +8005,7 @@
             "version": "2.2.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -8165,6 +8220,7 @@
             "version": "4.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-runner/-/loader-runner-4.3.0.tgz",
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -8173,6 +8229,7 @@
             "version": "2.0.4",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
             "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -8412,7 +8469,8 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -8461,6 +8519,7 @@
             "version": "1.52.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -8469,6 +8528,7 @@
             "version": "2.1.35",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -8894,7 +8954,8 @@
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -9025,7 +9086,8 @@
         "node_modules/node-releases": {
             "version": "2.0.8",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-releases/-/node-releases-2.0.8.tgz",
-            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
+            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+            "dev": true
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -9836,7 +9898,8 @@
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -10201,6 +10264,7 @@
             "version": "2.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10249,6 +10313,7 @@
             "version": "2.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
@@ -10816,7 +10881,8 @@
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/safe-regex-test": {
             "version": "1.0.0",
@@ -10861,6 +10927,7 @@
             "version": "3.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -11278,6 +11345,7 @@
             "version": "0.6.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11295,6 +11363,7 @@
             "version": "0.5.21",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -11662,6 +11731,7 @@
             "version": "2.2.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -11744,6 +11814,7 @@
             "version": "5.16.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser/-/terser-5.16.1.tgz",
             "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
@@ -11929,6 +12000,7 @@
             "version": "8.8.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn/-/acorn-8.8.1.tgz",
             "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -11939,7 +12011,8 @@
         "node_modules/terser/node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",
@@ -12270,6 +12343,7 @@
             "version": "1.0.10",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
             "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "dev": true,
             "dependencies": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"
@@ -12285,6 +12359,7 @@
             "version": "4.4.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -12293,6 +12368,7 @@
             "version": "4.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url-loader/-/url-loader-4.1.1.tgz",
             "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
+            "dev": true,
             "dependencies": {
                 "loader-utils": "^2.0.0",
                 "mime-types": "^2.1.27",
@@ -12375,6 +12451,7 @@
             "version": "2.4.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-2.4.0.tgz",
             "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "dev": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -12402,6 +12479,7 @@
             "version": "5.59.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack/-/webpack-5.59.1.tgz",
             "integrity": "sha512-I01IQV9K96FlpXX3V0L4nvd7gb0r7thfuu1IfT2P4uOHOA77nKARAKDYGe/tScSHKnffNIyQhLC8kRXzY4KEHQ==",
+            "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
                 "@types/estree": "^0.0.50",
@@ -12857,6 +12935,7 @@
             "version": "8.8.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn/-/acorn-8.8.1.tgz",
             "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -12868,6 +12947,7 @@
             "version": "1.8.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
             "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^8"
             }
@@ -12876,6 +12956,7 @@
             "version": "4.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -12884,6 +12965,7 @@
             "version": "27.5.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -12897,6 +12979,7 @@
             "version": "6.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
             "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -12905,6 +12988,7 @@
             "version": "8.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -12916,6 +13000,7 @@
             "version": "5.3.6",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
             "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.14",
                 "jest-worker": "^27.4.5",
@@ -12945,6 +13030,7 @@
             "version": "3.2.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "dev": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -14641,17 +14727,20 @@
         "@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true
         },
         "@jridgewell/set-array": {
             "version": "1.1.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true
         },
         "@jridgewell/source-map": {
             "version": "0.3.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/source-map/-/source-map-0.3.2.tgz",
             "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dev": true,
             "requires": {
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "@jridgewell/trace-mapping": "^0.3.9"
@@ -14661,6 +14750,7 @@
                     "version": "0.3.2",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
                     "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+                    "dev": true,
                     "requires": {
                         "@jridgewell/set-array": "^1.0.1",
                         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -14672,12 +14762,14 @@
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.17",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
             "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -14972,6 +15064,7 @@
             "version": "8.4.10",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/eslint/-/eslint-8.4.10.tgz",
             "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
+            "dev": true,
             "requires": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -14981,6 +15074,7 @@
             "version": "3.7.4",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
             "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+            "dev": true,
             "requires": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -14989,7 +15083,8 @@
         "@types/estree": {
             "version": "0.0.50",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+            "dev": true
         },
         "@types/express": {
             "version": "4.17.15",
@@ -15048,7 +15143,8 @@
         "@types/json-schema": {
             "version": "7.0.11",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/json-schema/-/json-schema-7.0.11.tgz",
-            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "dev": true
         },
         "@types/json5": {
             "version": "0.0.29",
@@ -15086,7 +15182,8 @@
         "@types/node": {
             "version": "13.7.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@types/node/-/node-13.7.1.tgz",
-            "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
+            "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==",
+            "dev": true
         },
         "@types/prop-types": {
             "version": "15.7.5",
@@ -15267,6 +15364,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ast/-/ast-1.11.1.tgz",
             "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/helper-numbers": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -15275,22 +15373,26 @@
         "@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "dev": true
         },
         "@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "dev": true
         },
         "@webassemblyjs/helper-buffer": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "dev": true
         },
         "@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
             "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -15300,12 +15402,14 @@
         "@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "dev": true
         },
         "@webassemblyjs/helper-wasm-section": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
             "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -15317,6 +15421,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
             "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -15325,6 +15430,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
             "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
@@ -15332,12 +15438,14 @@
         "@webassemblyjs/utf8": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "dev": true
         },
         "@webassemblyjs/wasm-edit": {
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
             "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -15353,6 +15461,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
             "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -15365,6 +15474,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
             "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -15376,6 +15486,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
             "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -15389,6 +15500,7 @@
             "version": "1.11.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
             "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
@@ -15420,12 +15532,14 @@
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true
         },
         "@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true
         },
         "accepts": {
             "version": "1.3.8",
@@ -15485,6 +15599,7 @@
             "version": "6.12.6",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -15497,15 +15612,14 @@
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.12.0",
-                    "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-8.12.0.tgz",
+                    "version": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv/-/ajv-8.12.0.tgz",
                     "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
                     "dev": true,
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -15517,7 +15631,9 @@
                     "version": "1.0.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -15525,6 +15641,7 @@
             "version": "3.5.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "dev": true,
             "requires": {}
         },
         "ansi-colors": {
@@ -15885,7 +16002,8 @@
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -15991,6 +16109,7 @@
             "version": "4.21.4",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/browserslist/-/browserslist-4.21.4.tgz",
             "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+            "dev": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -16007,7 +16126,8 @@
         "buffer-from": {
             "version": "1.1.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
         },
         "buffer-indexof": {
             "version": "1.1.1",
@@ -16149,7 +16269,8 @@
         "caniuse-lite": {
             "version": "1.0.30001442",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-            "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow=="
+            "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+            "dev": true
         },
         "chai": {
             "version": "4.2.0",
@@ -16213,7 +16334,8 @@
         "chrome-trace-event": {
             "version": "1.0.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true
         },
         "chromedriver": {
             "version": "92.0.2",
@@ -17099,7 +17221,8 @@
         "electron-to-chromium": {
             "version": "1.4.284",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
+            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "dev": true
         },
         "emoji-regex": {
             "version": "9.2.2",
@@ -17110,7 +17233,8 @@
         "emojis-list": {
             "version": "3.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -17131,6 +17255,7 @@
             "version": "5.12.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
             "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -17225,7 +17350,8 @@
         "es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true
         },
         "es-set-tostringtag": {
             "version": "2.0.1",
@@ -17273,7 +17399,8 @@
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
         },
         "escape-html": {
             "version": "1.0.3",
@@ -17640,6 +17767,7 @@
             "version": "5.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
             "requires": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -17714,6 +17842,7 @@
             "version": "4.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
             "requires": {
                 "estraverse": "^5.2.0"
             },
@@ -17721,14 +17850,16 @@
                 "estraverse": {
                     "version": "5.3.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "dev": true
                 }
             }
         },
         "estraverse": {
             "version": "4.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
         },
         "esutils": {
             "version": "2.0.3",
@@ -17751,7 +17882,8 @@
         "events": {
             "version": "3.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true
         },
         "execa": {
             "version": "5.1.1",
@@ -17933,7 +18065,8 @@
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
         },
         "fast-glob": {
             "version": "3.2.12",
@@ -17951,7 +18084,8 @@
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -18005,7 +18139,7 @@
             "version": "6.2.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/file-loader/-/file-loader-6.2.0.tgz",
             "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0"
@@ -18369,7 +18503,8 @@
         "glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true
         },
         "globals": {
             "version": "11.12.0",
@@ -18439,7 +18574,8 @@
         "graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "growl": {
             "version": "1.10.5",
@@ -19493,12 +19629,14 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -19515,7 +19653,8 @@
         "json5": {
             "version": "2.2.3",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true
         },
         "jss": {
             "version": "10.9.2",
@@ -19708,12 +19847,14 @@
         "loader-runner": {
             "version": "4.3.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "dev": true
         },
         "loader-utils": {
             "version": "2.0.4",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/loader-utils/-/loader-utils-2.0.4.tgz",
             "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -19912,7 +20053,8 @@
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "merge2": {
             "version": "1.4.1",
@@ -19945,12 +20087,14 @@
         "mime-db": {
             "version": "1.52.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true
         },
         "mime-types": {
             "version": "2.1.35",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
             "requires": {
                 "mime-db": "1.52.0"
             }
@@ -20287,7 +20431,8 @@
         "neo-async": {
             "version": "2.6.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
         },
         "nice-try": {
             "version": "1.0.5",
@@ -20396,7 +20541,8 @@
         "node-releases": {
             "version": "2.0.8",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/node-releases/-/node-releases-2.0.8.tgz",
-            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
+            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+            "dev": true
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -21052,7 +21198,8 @@
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
         },
         "picomatch": {
             "version": "2.3.1",
@@ -21332,7 +21479,8 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
         },
         "qs": {
             "version": "6.11.0",
@@ -21369,6 +21517,7 @@
             "version": "2.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
             }
@@ -21840,7 +21989,8 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "safe-regex-test": {
             "version": "1.0.0",
@@ -21884,6 +22034,7 @@
             "version": "3.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -22246,7 +22397,8 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
         },
         "source-map-js": {
             "version": "1.0.2",
@@ -22258,6 +22410,7 @@
             "version": "0.5.21",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -22567,7 +22720,8 @@
         "tapable": {
             "version": "2.2.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "dev": true
         },
         "tar": {
             "version": "6.1.13",
@@ -22631,6 +22785,7 @@
             "version": "5.16.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser/-/terser-5.16.1.tgz",
             "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+            "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",
                 "acorn": "^8.5.0",
@@ -22641,12 +22796,14 @@
                 "acorn": {
                     "version": "8.8.1",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn/-/acorn-8.8.1.tgz",
-                    "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+                    "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+                    "dev": true
                 },
                 "commander": {
                     "version": "2.20.3",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
                 }
             }
         },
@@ -23045,6 +23202,7 @@
             "version": "1.0.10",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
             "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "dev": true,
             "requires": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"
@@ -23054,6 +23212,7 @@
             "version": "4.4.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -23062,6 +23221,7 @@
             "version": "4.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/url-loader/-/url-loader-4.1.1.tgz",
             "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
+            "dev": true,
             "requires": {
                 "loader-utils": "^2.0.0",
                 "mime-types": "^2.1.27",
@@ -23123,6 +23283,7 @@
             "version": "2.4.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/watchpack/-/watchpack-2.4.0.tgz",
             "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -23147,6 +23308,7 @@
             "version": "5.59.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack/-/webpack-5.59.1.tgz",
             "integrity": "sha512-I01IQV9K96FlpXX3V0L4nvd7gb0r7thfuu1IfT2P4uOHOA77nKARAKDYGe/tScSHKnffNIyQhLC8kRXzY4KEHQ==",
+            "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
                 "@types/estree": "^0.0.50",
@@ -23177,23 +23339,27 @@
                 "acorn": {
                     "version": "8.8.1",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn/-/acorn-8.8.1.tgz",
-                    "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+                    "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+                    "dev": true
                 },
                 "acorn-import-assertions": {
                     "version": "1.8.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
                     "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+                    "dev": true,
                     "requires": {}
                 },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
                 },
                 "jest-worker": {
                     "version": "27.5.1",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/jest-worker/-/jest-worker-27.5.1.tgz",
                     "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+                    "dev": true,
                     "requires": {
                         "@types/node": "*",
                         "merge-stream": "^2.0.0",
@@ -23204,6 +23370,7 @@
                     "version": "6.0.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
                     "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+                    "dev": true,
                     "requires": {
                         "randombytes": "^2.1.0"
                     }
@@ -23212,6 +23379,7 @@
                     "version": "8.1.1",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/supports-color/-/supports-color-8.1.1.tgz",
                     "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -23220,6 +23388,7 @@
                     "version": "5.3.6",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
                     "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+                    "dev": true,
                     "requires": {
                         "@jridgewell/trace-mapping": "^0.3.14",
                         "jest-worker": "^27.4.5",
@@ -23231,7 +23400,8 @@
                 "webpack-sources": {
                     "version": "3.2.3",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/webpack-sources/-/webpack-sources-3.2.3.tgz",
-                    "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+                    "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "redux-immutable": "4.0.0",
         "redux-logger": "3.0.6",
         "redux-thunk": "2.3.0",
-        "url-loader": "4.1.1",
         "whatwg-fetch": "2.0.3"
     },
     "devDependencies": {
@@ -71,6 +70,7 @@
         "terser-webpack-plugin": "3.0.6",
         "ts-node": "8.6.2",
         "typescript": "3.7.5",
+        "url-loader": "4.1.1",
         "webpack": "5.59.1",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.9.1",


### PR DESCRIPTION
Signed-off-by: Martin Zeithaml <Martin.Zeithaml@broadcom.com>

This PR addresses Issue: no issue created for this.

## PR Type
- [ ] Bug fix
- [ ] Feature
- [x] Other (Please indicate):

`url-loader` was specified under `Dependencies` instead of `devDependencies`. This might (under some circumstances) trigger false security alert by vulnerability scanning tools.

### Notes: 
1. `url-loader` is used to code images to base64. Not needed in runtime. 
2. More specific, security alert might be caused by `loader-utils`, which is dependency of `url-loader`