### PR TITLE
Fix endpoint for v3 zosmf route

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: '[Prep 4] Setup Node'
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 16
 
       # - name: '[Prep extra] explorer-mvs exclusive - upgrade npm to v7'
       #   run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -61,9 +61,9 @@ jobs:
         uses: zowe-actions/shared-actions/prepare-workflow@main
 
       - name: '[Prep 4] Setup Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       # - name: '[Prep extra] explorer-mvs exclusive - upgrade npm to v7'
       #   run: |

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -20,13 +20,12 @@ export function whichServer() {
     return server;
 }
 
-
 // zosmf/
 const ZOSMF_PREFIX_LENGTH = 6;
 
 export function atlasAction(endpoint, content) {
     // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-    let trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+    const trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
 
     return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf${trimmedEndpoint}`, content);
 }

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -20,7 +20,14 @@ export function whichServer() {
     return server;
 }
 
+
+// zosmf/
+const ZOSMF_PREFIX_LENGTH = 6;
+
 export function atlasAction(endpoint, content) {
+    // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
+    endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+
     return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf${endpoint}`, content);
 }
 

--- a/WebContent/js/utilities/urlUtils.js
+++ b/WebContent/js/utilities/urlUtils.js
@@ -26,9 +26,9 @@ const ZOSMF_PREFIX_LENGTH = 6;
 
 export function atlasAction(endpoint, content) {
     // In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL, so string must be trimmed.
-    endpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
+    let trimmedEndpoint = endpoint.substring(ZOSMF_PREFIX_LENGTH);
 
-    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf${endpoint}`, content);
+    return fetch(`https://${whichServer()}/ibmzosmf/api/v1/zosmf${trimmedEndpoint}`, content);
 }
 
 export function atlasGet(endpoint) {

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -17,12 +17,12 @@ FROM zowe-docker-release.jfrog.io/ompzowe/base-node:${ZOWE_BASE_IMAGE} AS builde
 ##################################
 # labels
 LABEL name="MVS Explorer" \
-      maintainer="jack-tiefeng.jia@ibm.com" \
-      vendor="Zowe" \
-      version="0.0.0" \
-      release="0" \
-      summary="IBM z/OS Unix Datasets UI service" \
-      description="This Zowe UI component can display MVS datasets on z/OS"
+    maintainer="jack-tiefeng.jia@ibm.com" \
+    vendor="Zowe" \
+    version="0.0.0" \
+    release="0" \
+    summary="IBM z/OS Unix Datasets UI service" \
+    description="This Zowe UI component can display MVS datasets on z/OS"
 
 ##################################
 # switch context
@@ -39,7 +39,7 @@ COPY --chown=zowe:zowe component .
 # pretty same as .pax/prepare-workspace.sh. any way we can merge?
 RUN mkdir -p ~/.npm-global \
     && npm config set prefix '~/.npm-global' \
-    && npm install -g npm \
+    && npm install -g npm@7.24.2 \
     && ~/.npm-global/bin/npm install --no-audit --ignore-scripts --no-optional --legacy-peer-deps \
     && ~/.npm-global/bin/npm run prod \
     && mkdir -p final/web \

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@
 name: explorer-mvs
 # Component identifier. This identifier matches artifact path in Zowe Artifactory https://zowe.jfrog.io/.
 id: org.zowe.explorer-mvs
-version: 2.0.7
+version: 2.0.9
 # Component version is defined in gradle.properties for Gradle project
 # Human readable component name
 title: MVS Explorer

--- a/package-lock.json
+++ b/package-lock.json
@@ -5430,6 +5430,19 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
             }
         },
+        "node_modules/eslint-plugin-react-hooks": {
+            "version": "4.6.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            }
+        },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/doctrine/-/doctrine-2.1.0.tgz",
@@ -14829,7 +14842,8 @@
         "@material-ui/types": {
             "version": "5.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@material-ui/types/-/types-5.1.0.tgz",
-            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+            "requires": {}
         },
         "@material-ui/utils": {
             "version": "4.11.3",
@@ -15499,7 +15513,8 @@
             "version": "1.2.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
             "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@webpack-cli/info": {
             "version": "1.5.0",
@@ -15514,7 +15529,8 @@
             "version": "1.7.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webpack-cli/serve/-/serve-1.7.0.tgz",
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -15548,7 +15564,8 @@
             "version": "5.3.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "8.2.0",
@@ -15626,7 +15643,8 @@
             "version": "3.5.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-colors": {
             "version": "4.1.3",
@@ -17739,6 +17757,14 @@
                 }
             }
         },
+        "eslint-plugin-react-hooks": {
+            "version": "4.6.0",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -18831,7 +18857,8 @@
             "version": "5.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ignore": {
             "version": "4.0.6",
@@ -21316,7 +21343,8 @@
             "version": "3.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -21705,7 +21733,8 @@
         "redux-immutable": {
             "version": "4.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/redux-immutable/-/redux-immutable-4.0.0.tgz",
-            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg=="
+            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
+            "requires": {}
         },
         "redux-logger": {
             "version": "3.0.6",
@@ -22640,7 +22669,8 @@
             "version": "3.3.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/style-loader/-/style-loader-3.3.1.tgz",
             "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "supports-color": {
             "version": "5.5.0",
@@ -23324,7 +23354,8 @@
                     "version": "1.8.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
                     "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 },
                 "has-flag": {
                     "version": "4.0.0",
@@ -23661,7 +23692,8 @@
                     "version": "8.11.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ws/-/ws-8.11.0.tgz",
                     "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -23868,7 +23900,8 @@
             "version": "7.5.9",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xml": {
             "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "explorer-mvs",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "explorer-mvs",
-            "version": "2.0.9",
+            "version": "2.0.10",
             "license": "EPL-2.0",
             "dependencies": {
                 "@material-ui/core": "4.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@material-ui/core": "4.11.0",
                 "@material-ui/icons": "4.9.1",
                 "babel-polyfill": "6.16.0",
-                "immutable": "3.8.1",
+                "immutable": "3.8.2",
                 "orion-editor-component": "0.0.14",
                 "prop-types": "15.7.2",
                 "query-string": "6.8.2",
@@ -5430,19 +5430,6 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
             }
         },
-        "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-            }
-        },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/doctrine/-/doctrine-2.1.0.tgz",
@@ -7022,9 +7009,9 @@
             "dev": true
         },
         "node_modules/immutable": {
-            "version": "3.8.1",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.1.tgz",
-            "integrity": "sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==",
+            "version": "3.8.2",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.2.tgz",
+            "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14842,8 +14829,7 @@
         "@material-ui/types": {
             "version": "5.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@material-ui/types/-/types-5.1.0.tgz",
-            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-            "requires": {}
+            "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
         },
         "@material-ui/utils": {
             "version": "4.11.3",
@@ -15513,8 +15499,7 @@
             "version": "1.2.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
             "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@webpack-cli/info": {
             "version": "1.5.0",
@@ -15529,8 +15514,7 @@
             "version": "1.7.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@webpack-cli/serve/-/serve-1.7.0.tgz",
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -15564,8 +15548,7 @@
             "version": "5.3.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "8.2.0",
@@ -15643,8 +15626,7 @@
             "version": "3.5.2",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ansi-colors": {
             "version": "4.1.3",
@@ -17757,14 +17739,6 @@
                 }
             }
         },
-        "eslint-plugin-react-hooks": {
-            "version": "4.6.0",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "peer": true,
-            "requires": {}
-        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -18857,8 +18831,7 @@
             "version": "5.1.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ignore": {
             "version": "4.0.6",
@@ -18873,9 +18846,9 @@
             "dev": true
         },
         "immutable": {
-            "version": "3.8.1",
-            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.1.tgz",
-            "integrity": "sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ=="
+            "version": "3.8.2",
+            "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/immutable/-/immutable-3.8.2.tgz",
+            "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg=="
         },
         "import-fresh": {
             "version": "3.3.0",
@@ -21343,8 +21316,7 @@
             "version": "3.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -21733,8 +21705,7 @@
         "redux-immutable": {
             "version": "4.0.0",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/redux-immutable/-/redux-immutable-4.0.0.tgz",
-            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
-            "requires": {}
+            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg=="
         },
         "redux-logger": {
             "version": "3.0.6",
@@ -22669,8 +22640,7 @@
             "version": "3.3.1",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/style-loader/-/style-loader-3.3.1.tgz",
             "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "supports-color": {
             "version": "5.5.0",
@@ -23354,8 +23324,7 @@
                     "version": "1.8.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
                     "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 },
                 "has-flag": {
                     "version": "4.0.0",
@@ -23692,8 +23661,7 @@
                     "version": "8.11.0",
                     "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ws/-/ws-8.11.0.tgz",
                     "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 }
             }
         },
@@ -23900,8 +23868,7 @@
             "version": "7.5.9",
             "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml": {
             "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "explorer-mvs",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "explorer-mvs",
-            "version": "2.0.8",
+            "version": "2.0.9",
             "license": "EPL-2.0",
             "dependencies": {
                 "@material-ui/core": "4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "explorer-mvs",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "directories": {
         "test": "tests"
     },
@@ -8,7 +8,7 @@
         "@material-ui/core": "4.11.0",
         "@material-ui/icons": "4.9.1",
         "babel-polyfill": "6.16.0",
-        "immutable": "3.8.1",
+        "immutable": "3.8.2",
         "orion-editor-component": "0.0.14",
         "prop-types": "15.7.2",
         "query-string": "6.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "explorer-mvs",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "directories": {
         "test": "tests"
     },

--- a/tests/UnitTests/testResources/hostConstants.js
+++ b/tests/UnitTests/testResources/hostConstants.js
@@ -11,4 +11,4 @@
 export const LOCAL_HOSTNAME = 'tester.test.com';
 export const LOCAL_HOST_SERVER = `${LOCAL_HOSTNAME}:7443`;
 export const LOCAL_HOST_SERVER_WITH_PROTOCOL = `https://${LOCAL_HOST_SERVER}`;
-export const LOCAL_HOST_ENDPOINT = `${LOCAL_HOST_SERVER_WITH_PROTOCOL}/ibmzosmf/api/v1/zosmf`;
+export const LOCAL_HOST_ENDPOINT = `${LOCAL_HOST_SERVER_WITH_PROTOCOL}/ibmzosmf/api/v1/`;


### PR DESCRIPTION
In v3, /ibmzosmf/api/v1 endpoint removes /zosmf part of a /zosmf URL.
All URLs to zosmf in explorers are in form of 'zosmf/rest...' and are prefixed with APIML route in a single function.
So in this function, a substring operation is performed.